### PR TITLE
Rend update optionnel dans AbstractEngine

### DIFF
--- a/examples/jeu2048.py
+++ b/examples/jeu2048.py
@@ -145,10 +145,6 @@ def touche(key: str):
         ajouter_tuile()
 
 
-def update():
-    pass
-
-
 def draw():
     for i in range(TAILLE):
         for j in range(TAILLE):
@@ -160,6 +156,6 @@ if __name__ == "__main__":
     jeu = metagrid.create(TAILLE, TAILLE, TAILLE_CASE, 8)
     jeu.init(init)
     jeu.callback_key(touche)
-    jeu.update(update)
+
     jeu.draw(draw)
     jeu.start()

--- a/examples/lights_out.py
+++ b/examples/lights_out.py
@@ -75,11 +75,6 @@ def touche(key: str):
         init()
 
 
-def update():
-    """Aucune logique temporelle dans ce jeu : tout se passe sur événement."""
-    pass
-
-
 def draw():
     """Colorie chaque cellule selon son état : allumée, éteinte, ou victoire."""
     for i in range(NB_LIGNES):
@@ -97,6 +92,5 @@ if __name__ == "__main__":
     jeu.init(init)
     jeu.callback_click(cliquer)
     jeu.callback_key(touche)
-    jeu.update(update)
     jeu.draw(draw)
     jeu.start()

--- a/examples/puissance4.py
+++ b/examples/puissance4.py
@@ -102,10 +102,6 @@ def touche(key: str):
         jouer_dans_colonne(int(key) - 1)
 
 
-def update():
-    pass
-
-
 def draw():
     couleurs = {0: COULEUR_FOND, 1: COULEUR_J1, 2: COULEUR_J2}
     gagnantes = set(cellules_gagnantes)
@@ -122,6 +118,6 @@ if __name__ == "__main__":
     jeu.init(init)
     jeu.callback_click(cliquer)
     jeu.callback_key(touche)
-    jeu.update(update)
+
     jeu.draw(draw)
     jeu.start()

--- a/examples/sokoban.py
+++ b/examples/sokoban.py
@@ -100,10 +100,6 @@ def dessiner():
             jeu.set_cell_image(i, j, tiles[grille[i][j]])
 
 
-def update():
-    pass
-
-
 if __name__ == "__main__":
     niveau = int(sys.argv[1])
     if not (0 <= niveau < len(maps)):
@@ -116,5 +112,4 @@ if __name__ == "__main__":
     jeu.init(init)
     jeu.callback_key(touche)
     jeu.draw(dessiner)
-    jeu.update(update)
     jeu.start()

--- a/examples/taquin.py
+++ b/examples/taquin.py
@@ -82,10 +82,6 @@ def affiche_grille():
                 jeu.set_cell_color(i, j, "#FFFFFF")
 
 
-def update():
-    pass
-
-
 if __name__ == "__main__":
     jeu = metagrid.create(NB_LIGNES, NB_COLONNES, TAILLE_CASE, 0)
     for i in range(16):
@@ -93,5 +89,4 @@ if __name__ == "__main__":
     jeu.init(init)
     jeu.callback_click(cliquer)
     jeu.draw(affiche_grille)
-    jeu.update(update)
     jeu.start()

--- a/examples/wordle.py
+++ b/examples/wordle.py
@@ -111,10 +111,6 @@ def dessiner():
                 jeu.set_cell_image(i, j, "vide")
 
 
-def update():
-    pass
-
-
 if __name__ == "__main__":
     jeu = metagrid.create(NB_LIGNES, NB_COLONNES, CELL_SIZE, 4)
     images = ["curseur", "faux", "malplace", "trouve", "vide"]
@@ -123,5 +119,4 @@ if __name__ == "__main__":
     jeu.init(init)
     jeu.callback_key(touche)
     jeu.draw(dessiner)
-    jeu.update(update)
     jeu.start()

--- a/src/metagrid/backends/abstract.py
+++ b/src/metagrid/backends/abstract.py
@@ -56,10 +56,13 @@ class AbstractEngine(metaclass = ABCMeta):
 
     @abstractmethod
     def start(self) -> None:
-        """Start the game loop. Register all callbacks with decorators before calling this."""
+        """Start the game loop. Register all callbacks before calling this.
+
+        Required: init, draw.
+        Optional: update, callback_click, callback_key.
+        """
         assert self._init_fn is not None, "An init function must be registered with @game.init"
         assert self.fn_draw is not None, "A draw function must be registered with @game.draw"
-        assert self.fn_update is not None, "An update function must be registered with @game.update"
         self._init_fn()
         ...
 


### PR DESCRIPTION
## Résumé

- Supprime l'assertion sur `fn_update` dans `AbstractEngine.start()` : `update` est désormais optionnel comme `callback_click`
- L'implémentation arcade gérait déjà silencieusement le cas `None` (`if self.crafter.fn_update:`)
- Nettoie les exemples sans logique temporelle (`taquin`, `sokoban`, `wordle`, `puissance4`, `jeu2048`, `lights_out`) en retirant les `def update(): pass` et leurs enregistrements

Fixes #3